### PR TITLE
removed suffix from sed in-place option in favor of editing directly in file

### DIFF
--- a/build-test/package.sh
+++ b/build-test/package.sh
@@ -26,13 +26,13 @@ mix new myhtmlex_pkg_test
 cd myhtmlex_pkg_test
 
 # Default operation
-sed -i "" -e 's/^.*dep_from_hexpm.*$/      {:myhtmlex, path: "..\/myhtmlex-local"}/' mix.exs
+sed -i -e 's/^.*dep_from_hexpm.*$/      {:myhtmlex, path: "..\/myhtmlex-local"}/' mix.exs
 mix deps.get
 mix compile
 mix run -e 'IO.inspect {"html", [], [{"head", [], []}, {"body", [], ["foo"]}]} = Myhtmlex.decode("foo")'
 
 # Nif operation
-sed -i "" -e 's/^.*myhtmlex-local.*$/      {:myhtmlex, path: "..\/myhtmlex-local", runtime: false}/' mix.exs
+sed -i -e 's/^.*myhtmlex-local.*$/      {:myhtmlex, path: "..\/myhtmlex-local", runtime: false}/' mix.exs
 echo "config :myhtmlex, mode: Myhtmlex.Nif" >> config/config.exs
 mix run -e 'IO.inspect {"html", [], [{"head", [], []}, {"body", [], ["foo"]}]} = Myhtmlex.decode("foo")'
 


### PR DESCRIPTION
Ubuntu 14.04
Erlang/OTP 20 [erts-9.2]
gcc version 4.8.5
**branch: v0.2**

Running the package test script.
`./build-test/package.sh`

The `sed` command on line [29](https://github.com/Overbryd/myhtmlex/blob/v0.2/build-test/package.sh#L29) and [35](https://github.com/Overbryd/myhtmlex/blob/v0.2/build-test/package.sh#L29) returns with:

`sed: can't read : No such file or directory`

The behavior of `sed -i` is different on mac os and linux.

`-i[SUFFIX]`
`--in-place[=SUFFIX]`

The GNU `sed` does not allow a space between option `-i` and `[SUFFIX]`.

> -i means in-place, that is, edit in the file directly.
> -i '' means edit in place a file whose name is the empty string.
> Since there probably is no file whose name is the empty string, sed complains that it cannot read it. 

See this [post](https://stackoverflow.com/a/43453459)

Removing the suffix in favor of editing directly in file fixes the problem on my side.
This should also work on mac os.