### PR TITLE
cnode: Use an identifiable prefix for snames

### DIFF
--- a/lib/myhtmlex/safe.ex
+++ b/lib/myhtmlex/safe.ex
@@ -5,6 +5,11 @@ defmodule Myhtmlex.Safe do
 
   app = Mix.Project.config[:app]
 
+
+  defp random_sname, do: :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
+
+  defp sname, do: :"myhtmlex_#{random_sname()}"
+
   def start(_type, _args) do
     import Supervisor.Spec
     unless Node.alive? do
@@ -12,7 +17,7 @@ defmodule Myhtmlex.Safe do
     end
     myhtml_worker = Path.join(:code.priv_dir(unquote(app)), "myhtml_worker")
     children = [
-      worker(Nodex.Cnode, [%{exec_path: myhtml_worker}, [name: Myhtmlex.Safe.Cnode]])
+      worker(Nodex.Cnode, [%{exec_path: myhtml_worker, sname: sname()}, [name: Myhtmlex.Safe.Cnode]])
     ]
     Supervisor.start_link(children, strategy: :one_for_one, name: Myhtmlex.Safe.Supervisor)
   end


### PR DESCRIPTION
Swarm tries to include the cnode into the hash ring and fails, interfering with the application startup. The solution is to give these nodes indentifiable snames, so they can be blacklisted from the Swarm hash ring.